### PR TITLE
feat: add Terraform module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @PrefectHQ/platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @PrefectHQ/platform
+@PrefectHQ/platform

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -1,0 +1,19 @@
+---
+name: Run pre-commit for static analysis
+
+"on":
+  pull_request: {}
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install tool dependencies
+        uses: jdx/mise-action@v2
+      - uses: pre-commit/action@v3.0.1

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,4 @@
+[tools]
+pre-commit = '3.7.1'
+terraform = '1.10.1'
+terraform-docs = '0.19.0'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.2.4
+  hooks:
+    - id: codespell
+- repo: local
+  hooks:
+    - id: terraform-docs
+      name: Terraform Provider Docs
+      files: ^(infra/amazon-ecs-worker/.*)$
+      entry: terraform-docs
+      args:
+        - markdown
+        - table
+        - infra/amazon-ecs-worker
+        - --output-file
+        - README.md
+      language: system
+      pass_filenames: false
+- repo: https://github.com/antonbabenko/pre-commit-terraform
+  rev: v1.83.5
+  hooks:
+    - id: terraform_fmt
+    - id: terraform_docs
+      args:
+        - "--args=--config=.terraform-docs.yaml"

--- a/.terraform-docs.yaml
+++ b/.terraform-docs.yaml
@@ -1,0 +1,24 @@
+---
+formatter: markdown
+settings:
+  anchor: true
+  color: true
+  default: true
+  escape: true
+  html: true
+  indent: 2
+  required: true
+  sensitive: true
+  type: true
+
+sort:
+  enabled: true
+  by: required
+
+output:
+  file: README.md
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Terraform Prefect ECS Module
 
 This module deploys a Prefect 3 worker onto ECS Fargate using
-[Terraform](https://www.terraform.io/). It is intended to be used as a
+[Terraform](https://www.terraform.io/).
 
 ![image](https://github.com/PrefectHQ/prefect-recipes/assets/68969861/d148af90-58dd-4ce2-a160-e23fada6c895)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Terraform Prefect ECS Module
 
-This module deploys a Prefect 3 worker onto ECS Fargate using
+This module deploys a Prefect worker onto ECS Fargate using
 [Terraform](https://www.terraform.io/).
 
 ![image](https://github.com/PrefectHQ/prefect-recipes/assets/68969861/d148af90-58dd-4ce2-a160-e23fada6c895)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 This module deploys a Prefect 3 worker onto ECS Fargate using
 [Terraform](https://www.terraform.io/). It is intended to be used as a
-Note that flows will run inside the worker ECS task, as opposed to becoming their own ECS tasks.
 
 ![image](https://github.com/PrefectHQ/prefect-recipes/assets/68969861/d148af90-58dd-4ce2-a160-e23fada6c895)
 

--- a/README.md
+++ b/README.md
@@ -126,18 +126,18 @@ No modules.
 | <a name="input_prefect_account_id"></a> [prefect\_account\_id](#input\_prefect\_account\_id) | Prefect Cloud account ID | `string` | n/a | yes |
 | <a name="input_prefect_api_key"></a> [prefect\_api\_key](#input\_prefect\_api\_key) | Prefect Cloud API key | `string` | n/a | yes |
 | <a name="input_prefect_workspace_id"></a> [prefect\_workspace\_id](#input\_prefect\_workspace\_id) | Prefect Cloud workspace ID | `string` | n/a | yes |
-| <a name="input_secrets_manager_recovery_in_days"></a> [secrets\_manager\_recovery\_in\_days](#input\_secrets\_manager\_recovery\_in\_days) | Deletion delay for AWS Secrets Manager upon resource destruction | `number` | `30` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID in which to create all resources | `string` | n/a | yes |
+| <a name="input_worker_subnets"></a> [worker\_subnets](#input\_worker\_subnets) | Subnet(s) to use for the worker | `list(string)` | n/a | yes |
+| <a name="input_worker_work_pool_name"></a> [worker\_work\_pool\_name](#input\_worker\_work\_pool\_name) | Work pool that the worker should poll | `string` | n/a | yes |
+| <a name="input_secrets_manager_recovery_in_days"></a> [secrets\_manager\_recovery\_in\_days](#input\_secrets\_manager\_recovery\_in\_days) | Deletion delay for AWS Secrets Manager upon resource destruction | `number` | `30` | no |
 | <a name="input_worker_cpu"></a> [worker\_cpu](#input\_worker\_cpu) | CPU units to allocate to the worker | `number` | `1024` | no |
 | <a name="input_worker_desired_count"></a> [worker\_desired\_count](#input\_worker\_desired\_count) | Number of workers to run | `number` | `1` | no |
 | <a name="input_worker_extra_pip_packages"></a> [worker\_extra\_pip\_packages](#input\_worker\_extra\_pip\_packages) | Packages to install on the worker assuming image is based on prefecthq/prefect | `string` | `"prefect-aws s3fs"` | no |
 | <a name="input_worker_image"></a> [worker\_image](#input\_worker\_image) | Container image for the worker. This could be the name of an image in a public repo or an ECR ARN | `string` | `"prefecthq/prefect:3-python3.11"` | no |
 | <a name="input_worker_log_retention_in_days"></a> [worker\_log\_retention\_in\_days](#input\_worker\_log\_retention\_in\_days) | Number of days to retain worker logs | `number` | `30` | no |
 | <a name="input_worker_memory"></a> [worker\_memory](#input\_worker\_memory) | Memory units to allocate to the worker | `number` | `2048` | no |
-| <a name="input_worker_subnets"></a> [worker\_subnets](#input\_worker\_subnets) | Subnet(s) to use for the worker | `list(string)` | n/a | yes |
 | <a name="input_worker_task_role_arn"></a> [worker\_task\_role\_arn](#input\_worker\_task\_role\_arn) | Optional task role ARN to pass to the worker. If not defined, a task role will be created | `string` | `null` | no |
 | <a name="input_worker_type"></a> [worker\_type](#input\_worker\_type) | Prefect worker type that gets passed into the Prefect worker start command | `string` | `"ecs"` | no |
-| <a name="input_worker_work_pool_name"></a> [worker\_work\_pool\_name](#input\_worker\_work\_pool\_name) | Work pool that the worker should poll | `string` | n/a | yes |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -129,8 +129,6 @@ terraform-docs markdown table . --output-file README.md
 - [Prefect ECS guide](https://docs.prefect.io/integrations/prefect-aws/ecs_guide)
 - [Amazon ECS networking best practices](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/networking-best-practices.html)
 - [Troubleshoot ECS pulling secrets](https://repost.aws/knowledge-center/ecs-unable-to-pull-secrets)
-- https://registry.terraform.io/providers/PrefectHQ/prefect/latest/docs/resources/deployment
-- https://docs.prefect.io/v3/deploy/infrastructure-concepts/prefect-yaml
 
 
 <!-- BEGIN_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -1,1 +1,151 @@
-# terraform-prefect-ecs-worker
+# Terraform Prefect ECS Module
+
+This module deploys a Prefect 3 worker onto ECS Fargate using
+[Terraform](https://www.terraform.io/). It is intended to be used as a
+Note that flows will run inside the worker ECS task, as opposed to becoming their own ECS tasks.
+
+![image](https://github.com/PrefectHQ/prefect-recipes/assets/68969861/d148af90-58dd-4ce2-a160-e23fada6c895)
+
+## Requirements
+
+To start, you will need:
+
+- A local installation of the Terraform CLI
+- Your Prefect account ID
+- Your Prefect workspace ID
+- Your Prefect API key
+- A subnet where Fargate will create ECS tasks
+- A name for your deployment
+
+## Usage
+
+In order to avoid accidentally committing your API key, consider structuring your project as follows,
+
+```
+.
+├── main.tf
+├── terraform.tfvars
+└── variables.tf
+```
+
+```hcl
+// variables.tf
+variable prefect_api_key {}
+```
+
+```hcl
+// terraform.tfvars
+prefect_api_key = "pnu_xxxxx"
+```
+
+```hcl
+// main.tf
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+// Don't panic! These values are just random uuid.uuid4()s
+module "prefect_ecs_worker" {
+  source = "github.com/PrefectHQ/examples/infra/amazon-ecs-worker"
+
+  vpc_id                = "vpc-acfc2092275244ca8"
+  worker_subnets        = [
+    "subnet-014aa5f348034e45b",
+    "subnet-df23ae9eab1f49af9"
+  ]
+  name                  = "dev"
+
+  prefect_api_key       = var.prefect_api_key
+  prefect_account_id    = "6e02a1db-07de-4760-a15d-60d8fe0b04e1"
+  prefect_workspace_id  = "54cdfc71-9f13-41ba-9492-e1cf24eed185"
+
+  worker_work_pool_name = "my-ecs-pool"
+}
+```
+
+Assuming the file structure above, you can run `terraform init` followed by
+`terraform apply` to create the resources. Check out the [Inputs](#inputs)
+section below for more options.
+
+Once complete, you will see a new work pool available in Prefect. You can then
+use this work pool for your deployments. See the
+[deployments documentation](https://docs.prefect.io/v3/deploy/index) for more information.
+
+## Reference
+
+The [terraform docs](https://terraform-docs.io/) below can be generated with the following command:
+
+```sh
+terraform-docs markdown table . --output-file README.md
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_log_group.prefect_worker_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_ecs_cluster.prefect_worker_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster) | resource |
+| [aws_ecs_cluster_capacity_providers.prefect_worker_cluster_capacity_providers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster_capacity_providers) | resource |
+| [aws_ecs_service.prefect_worker_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
+| [aws_ecs_task_definition.prefect_worker_task_definition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
+| [aws_iam_role.prefect_worker_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.prefect_worker_task_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.logs_allow_create_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.prefect_worker_allow_ecs_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.ssm_allow_read_prefect_api_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy_attachment.prefect_worker_ecs_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_secretsmanager_secret.prefect_api_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret_version.prefect_api_key_version](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_security_group.prefect_worker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.network_outbound](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_name"></a> [name](#input\_name) | Unique name for this worker deployment | `string` | n/a | yes |
+| <a name="input_prefect_account_id"></a> [prefect\_account\_id](#input\_prefect\_account\_id) | Prefect Cloud account ID | `string` | n/a | yes |
+| <a name="input_prefect_api_key"></a> [prefect\_api\_key](#input\_prefect\_api\_key) | Prefect Cloud API key | `string` | n/a | yes |
+| <a name="input_prefect_workspace_id"></a> [prefect\_workspace\_id](#input\_prefect\_workspace\_id) | Prefect Cloud workspace ID | `string` | n/a | yes |
+| <a name="input_secrets_manager_recovery_in_days"></a> [secrets\_manager\_recovery\_in\_days](#input\_secrets\_manager\_recovery\_in\_days) | Deletion delay for AWS Secrets Manager upon resource destruction | `number` | `30` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID in which to create all resources | `string` | n/a | yes |
+| <a name="input_worker_cpu"></a> [worker\_cpu](#input\_worker\_cpu) | CPU units to allocate to the worker | `number` | `1024` | no |
+| <a name="input_worker_desired_count"></a> [worker\_desired\_count](#input\_worker\_desired\_count) | Number of workers to run | `number` | `1` | no |
+| <a name="input_worker_extra_pip_packages"></a> [worker\_extra\_pip\_packages](#input\_worker\_extra\_pip\_packages) | Packages to install on the worker assuming image is based on prefecthq/prefect | `string` | `"prefect-aws s3fs"` | no |
+| <a name="input_worker_image"></a> [worker\_image](#input\_worker\_image) | Container image for the worker. This could be the name of an image in a public repo or an ECR ARN | `string` | `"prefecthq/prefect:3-python3.11"` | no |
+| <a name="input_worker_log_retention_in_days"></a> [worker\_log\_retention\_in\_days](#input\_worker\_log\_retention\_in\_days) | Number of days to retain worker logs | `number` | `30` | no |
+| <a name="input_worker_memory"></a> [worker\_memory](#input\_worker\_memory) | Memory units to allocate to the worker | `number` | `2048` | no |
+| <a name="input_worker_subnets"></a> [worker\_subnets](#input\_worker\_subnets) | Subnet(s) to use for the worker | `list(string)` | n/a | yes |
+| <a name="input_worker_task_role_arn"></a> [worker\_task\_role\_arn](#input\_worker\_task\_role\_arn) | Optional task role ARN to pass to the worker. If not defined, a task role will be created | `string` | `null` | no |
+| <a name="input_worker_type"></a> [worker\_type](#input\_worker\_type) | Prefect worker type that gets passed into the Prefect worker start command | `string` | `"ecs"` | no |
+| <a name="input_worker_work_pool_name"></a> [worker\_work\_pool\_name](#input\_worker\_work\_pool\_name) | Work pool that the worker should poll | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_prefect_worker_cluster_name"></a> [prefect\_worker\_cluster\_name](#output\_prefect\_worker\_cluster\_name) | n/a |
+| <a name="output_prefect_worker_execution_role_arn"></a> [prefect\_worker\_execution\_role\_arn](#output\_prefect\_worker\_execution\_role\_arn) | n/a |
+| <a name="output_prefect_worker_security_group"></a> [prefect\_worker\_security\_group](#output\_prefect\_worker\_security\_group) | n/a |
+| <a name="output_prefect_worker_service_id"></a> [prefect\_worker\_service\_id](#output\_prefect\_worker\_service\_id) | n/a |
+| <a name="output_prefect_worker_task_role_arn"></a> [prefect\_worker\_task\_role\_arn](#output\_prefect\_worker\_task\_role\_arn) | n/a |
+<!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ No modules.
 | [aws_ecs_task_definition.prefect_worker_task_definition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
 | [aws_iam_role.prefect_worker_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.prefect_worker_task_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy.logs_allow_create_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.allow_create_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.prefect_worker_allow_ecs_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.ssm_allow_read_prefect_api_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.prefect_worker_ecs_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |

--- a/ecs.tf
+++ b/ecs.tf
@@ -1,0 +1,72 @@
+resource "aws_ecs_cluster" "prefect_worker_cluster" {
+  name = "prefect-worker-${var.name}"
+}
+
+resource "aws_ecs_cluster_capacity_providers" "prefect_worker_cluster_capacity_providers" {
+  cluster_name       = aws_ecs_cluster.prefect_worker_cluster.name
+  capacity_providers = ["FARGATE"]
+}
+
+resource "aws_ecs_task_definition" "prefect_worker_task_definition" {
+  family = "prefect-worker-${var.name}"
+  cpu    = var.worker_cpu
+  memory = var.worker_memory
+
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+
+  container_definitions = jsonencode([
+    {
+      name    = "prefect-worker-${var.name}"
+      image   = var.worker_image
+      command = ["prefect", "worker", "start", "-p", var.worker_work_pool_name, "--type", var.worker_type]
+      cpu     = var.worker_cpu
+      memory  = var.worker_memory
+      environment = [
+        {
+          name  = "PREFECT_API_URL"
+          value = "https://api.prefect.cloud/api/accounts/${var.prefect_account_id}/workspaces/${var.prefect_workspace_id}"
+        },
+        {
+          name  = "EXTRA_PIP_PACKAGES"
+          value = var.worker_extra_pip_packages
+        }
+      ]
+      secrets = [
+        {
+          name      = "PREFECT_API_KEY"
+          valueFrom = aws_secretsmanager_secret.prefect_api_key.arn
+        }
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.prefect_worker_log_group.name
+          awslogs-region        = data.aws_region.current.name
+          awslogs-stream-prefix = "prefect-worker-${var.name}"
+        }
+      }
+    }
+  ])
+
+  // Execution role allows ECS to create tasks and services.
+  execution_role_arn = aws_iam_role.prefect_worker_execution_role.arn
+
+  // Task role allows tasks and services to access other AWS resources.
+  // Use worker_task_role_arn if provided, otherwise populate with default.
+  task_role_arn = var.worker_task_role_arn == null ? aws_iam_role.prefect_worker_task_role[0].arn : var.worker_task_role_arn
+}
+
+resource "aws_ecs_service" "prefect_worker_service" {
+  name            = "prefect-worker-${var.name}"
+  cluster         = aws_ecs_cluster.prefect_worker_cluster.id
+  desired_count   = var.worker_desired_count
+  launch_type     = "FARGATE"
+  task_definition = aws_ecs_task_definition.prefect_worker_task_definition.arn
+
+  network_configuration {
+    assign_public_ip = false
+    security_groups  = [aws_security_group.prefect_worker.id]
+    subnets          = var.worker_subnets
+  }
+}

--- a/examples/ecs-worker/README.md
+++ b/examples/ecs-worker/README.md
@@ -3,6 +3,8 @@
 This example uses the [AWS VPC module](https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest)
 to create the AWS resources required for a functional ECS cluster to host the Prefect worker.
 
+## Usage
+
 Once the Terraform plan is applied successfully, you can test it by assigning a
 Deployment to the new ECS work pool. An example of the configuration for this
 is available in the [example `prefect.yaml` file](./prefect.yaml).
@@ -12,6 +14,12 @@ documentation for more information.
 The `build` and `push` steps defined in this file will build the [sample flow](./hello_world.py)
 into a Docker image and push it to the ECR repository created by Terraform. Some portions of
 this file will need to be replaced by the unique resource names created in AWS.
+
+Run `prefect deploy hello_world.py:hello_world` and follow the prompts. Once complete, you will
+see your Deployment in the UI. You can then start a run from the UI, or using the suggested
+command from the CLI. The flow run will execute on your new ECS work pool.
+
+## References
 
 As an alternative to `prefect.yaml`, deployments can be managed by Terraform using the Prefect provider's
 [`deployment` resource](https://registry.terraform.io/providers/PrefectHQ/prefect/latest/docs/resources/deployment).

--- a/examples/ecs-worker/README.md
+++ b/examples/ecs-worker/README.md
@@ -23,3 +23,38 @@ command from the CLI. The flow run will execute on your new ECS work pool.
 
 As an alternative to `prefect.yaml`, deployments can be managed by Terraform using the Prefect provider's
 [`deployment` resource](https://registry.terraform.io/providers/PrefectHQ/prefect/latest/docs/resources/deployment).
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_prefect_ecs_worker"></a> [prefect\_ecs\_worker](#module\_prefect\_ecs\_worker) | prefecthq/ecs-worker/prefect | 1.0.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 5.19.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_ecr_repository.example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/examples/ecs-worker/README.md
+++ b/examples/ecs-worker/README.md
@@ -1,0 +1,17 @@
+# Example: ECS worker
+
+This example uses the [AWS VPC module](https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest)
+to create the AWS resources required for a functional ECS cluster to host the Prefect worker.
+
+Once the Terraform plan is applied successfully, you can test it by assigning a
+Deployment to the new ECS work pool. An example of the configuration for this
+is available in the [example `prefect.yaml` file](./prefect.yaml).
+See the [Prefect YAML](https://docs.prefect.io/v3/deploy/infrastructure-concepts/prefect-yaml)
+documentation for more information.
+
+The `build` and `push` steps defined in this file will build the [sample flow](./hello_world.py)
+into a Docker image and push it to the ECR repository created by Terraform. Some portions of
+this file will need to be replaced by the unique resource names created in AWS.
+
+As an alternative to `prefect.yaml`, deployments can be managed by Terraform using the Prefect provider's
+[`deployment` resource](https://registry.terraform.io/providers/PrefectHQ/prefect/latest/docs/resources/deployment).

--- a/examples/ecs-worker/hello_world.py
+++ b/examples/ecs-worker/hello_world.py
@@ -1,0 +1,13 @@
+from prefect import flow
+
+
+@flow(log_prints=True)
+def hello_world(name: str = "world", goodbye: bool = False):
+    print(f"Hello {name} from Prefect! 🤗")
+
+    if goodbye:
+        print(f"Goodbye {name}!")
+
+
+if __name__ == "__main__":
+    hello_world()

--- a/examples/ecs-worker/main.tf
+++ b/examples/ecs-worker/main.tf
@@ -1,0 +1,100 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region     = "us-east-1"
+  access_key = var.access_key
+  secret_key = var.secret_key
+}
+
+locals {
+  azs = [
+    "us-east-1a",
+    "us-east-1b",
+    "us-east-1c",
+  ]
+
+  vpc_name                = "example-ecs-vpc"
+  base_vpc_cidr           = "10.0.0.0/16"
+  flow_log_retention_days = 7
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "5.19.0"
+
+  name = local.vpc_name
+  cidr = local.base_vpc_cidr
+  azs  = local.azs
+
+  # Enable a NAT gateway to allow private subnets to route traffic to the internet.
+  enable_nat_gateway = true
+  enable_vpn_gateway = false
+
+  # So as to not waste IP addresses, we only create one NAT gateway per AZ.
+  one_nat_gateway_per_az = true
+
+  # Create an internet gateway to allow public subnets to route traffic to the internet.
+  create_igw = true
+
+  # The public subnets are used to route traffic from private subnets to the internet through the NAT gateway.
+  # We only need one public subnet per AZ to route traffic to the internet from the private subnets.
+  public_subnets = [for k, v in local.azs : cidrsubnet(local.base_vpc_cidr, 4, k)]
+
+  # The private subnets are used to run the Prefect Server in Fargate.
+  private_subnets = concat(
+    # Assign primary VPC CIDR blocks to the private subnets
+    [for k, v in local.azs : cidrsubnet(local.base_vpc_cidr, 4, k + 3)],
+  )
+
+  private_subnet_names = [for k, v in local.azs : "${local.vpc_name}-private-${local.azs[k]}"]
+  public_subnet_names  = [for k, v in local.azs : "${local.vpc_name}-public-${local.azs[k]}"]
+
+  # Enable flow logs to capture all traffic in and out of the VPC.
+  enable_flow_log                                 = true
+  create_flow_log_cloudwatch_log_group            = true
+  create_flow_log_cloudwatch_iam_role             = true
+  flow_log_cloudwatch_log_group_retention_in_days = local.flow_log_retention_days
+
+  # The default security group is not used and by default the default security group
+  # is deny on all ports and protocols both ingress and egress.
+  manage_default_security_group = false
+
+  # The default route table is not used and does not need to be managed by Terraform.
+  manage_default_route_table = false
+
+  tags = {
+    Name = local.vpc_name
+  }
+}
+
+resource "aws_ecr_repository" "example" {
+  name                 = "example-ecs-worker"
+  image_tag_mutability = "MUTABLE"
+
+  tags = {
+    Name = local.vpc_name
+  }
+}
+
+module "prefect_ecs_worker" {
+  source  = "prefecthq/ecs-worker/prefect"
+  version = "1.0.0"
+
+  name = "example-ecs-worker"
+
+  vpc_id         = module.vpc.vpc_id
+  worker_subnets = module.vpc.private_subnets
+
+  prefect_api_key      = var.prefect_api_key
+  prefect_account_id   = "6e02a1db-07de-4760-a15d-60d8fe0b04e1"
+  prefect_workspace_id = "54cdfc71-9f13-41ba-9492-e1cf24eed185"
+
+  worker_work_pool_name = "example-ecs-pool"
+}

--- a/examples/ecs-worker/prefect.yaml
+++ b/examples/ecs-worker/prefect.yaml
@@ -1,0 +1,36 @@
+---
+name: ecs-worker-guide
+prefect-version: 3.2.11
+
+# build section allows you to manage and build docker images
+build:
+  - prefect_docker.deployments.steps.build_docker_image:
+      id: build_image
+      requires: prefect-docker>=0.3.1
+      image_name: 123456789.dkr.ecr.us-east-1.amazonaws.com/example-ecs-worker
+      tag: latest
+      dockerfile: auto
+      platform: amd64
+
+# push section allows you to manage if and how this project is uploaded to remote locations
+push:
+  - prefect_docker.deployments.steps.push_docker_image:
+      requires: prefect-docker>=0.3.1
+      image_name: '{{ build_image.image_name }}'
+      tag: '{{ build_image.tag }}'
+
+# the deployments section allows you to provide configuration for deploying flows
+deployments:
+  - name: my_ecs_deployment2
+    description: Test ECS worker deployment
+    entrypoint: hello_world.py:hello_world
+    work_pool:
+      name: example-ecs-pool
+      work_queue_name: default
+      job_variables: {
+        "image": '{{ build_image.image }}'
+      }
+
+pull:
+  - prefect.deployments.steps.set_working_directory:
+      directory: /opt/prefect

--- a/main.tf
+++ b/main.tf
@@ -66,7 +66,7 @@ resource "aws_iam_role_policy" "ssm_allow_read_prefect_api_key" {
   })
 }
 
-resource "aws_iam_role_policy" "logs_allow_create_log_group" {
+resource "aws_iam_role_policy" "allow_create_log_group" {
   name = "logs-allow-create-log-group-${var.name}"
   role = aws_iam_role.prefect_worker_execution_role.id
 

--- a/main.tf
+++ b/main.tf
@@ -124,6 +124,7 @@ resource "aws_iam_role_policy" "prefect_worker_allow_ecs_task" {
           "ecs:RegisterTaskDefinition",
           "ecs:RunTask",
           "ecs:StopTask",
+          "ecs:TagResource",
           "iam:PassRole",
           "logs:CreateLogGroup",
           "logs:CreateLogStream",

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,143 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+// Region specified in AWS provider
+data "aws_region" "current" {}
+
+resource "aws_secretsmanager_secret" "prefect_api_key" {
+  name                    = "prefect-api-key-${var.name}"
+  recovery_window_in_days = var.secrets_manager_recovery_in_days
+}
+
+resource "aws_secretsmanager_secret_version" "prefect_api_key_version" {
+  secret_id     = aws_secretsmanager_secret.prefect_api_key.id
+  secret_string = var.prefect_api_key
+}
+
+resource "aws_iam_role" "prefect_worker_execution_role" {
+  name = "prefect-worker-execution-role-${var.name}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "prefect_worker_ecs_policy" {
+  role = aws_iam_role.prefect_worker_execution_role.name
+
+  // AmazonECSTaskExecutionRolePolicy is an AWS managed role for creating ECS tasks and services
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy" "ssm_allow_read_prefect_api_key" {
+  name = "ssm-allow-read-prefect-api-key-${var.name}"
+  role = aws_iam_role.prefect_worker_execution_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "kms:Decrypt",
+          "secretsmanager:GetSecretValue",
+          "ssm:GetParameters"
+        ]
+        Effect = "Allow"
+        Resource = [
+          aws_secretsmanager_secret.prefect_api_key.arn
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "logs_allow_create_log_group" {
+  name = "logs-allow-create-log-group-${var.name}"
+  role = aws_iam_role.prefect_worker_execution_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "logs:CreateLogGroup",
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "prefect_worker_task_role" {
+  name  = "prefect-worker-task-role-${var.name}"
+  count = var.worker_task_role_arn == null ? 1 : 0
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "prefect_worker_allow_ecs_task" {
+  name  = "prefect-worker-allow-ecs-task-${var.name}"
+  count = var.worker_task_role_arn == null ? 1 : 0
+  role  = aws_iam_role.prefect_worker_task_role[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "ec2:DescribeSubnets",
+          "ec2:DescribeVpcs",
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:BatchGetImage",
+          "ecr:GetAuthorizationToken",
+          "ecr:GetDownloadUrlForLayer",
+          "ecs:DeregisterTaskDefinition",
+          "ecs:DescribeTaskDefinition",
+          "ecs:DescribeTasks",
+          "ecs:RegisterTaskDefinition",
+          "ecs:RunTask",
+          "ecs:StopTask",
+          "iam:PassRole",
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:GetLogEvents",
+          "logs:PutLogEvents"
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_cloudwatch_log_group" "prefect_worker_log_group" {
+  name              = "prefect-worker-log-group-${var.name}"
+  retention_in_days = var.worker_log_retention_in_days
+}

--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,3 @@
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 5.0"
-    }
-  }
-}
-
 // Region specified in AWS provider
 data "aws_region" "current" {}
 

--- a/network.tf
+++ b/network.tf
@@ -1,0 +1,20 @@
+resource "aws_security_group" "prefect_worker" {
+  name        = "prefect-worker-sg-${var.name}"
+  description = "ECS Prefect worker"
+  vpc_id      = var.vpc_id
+}
+
+resource "aws_security_group_rule" "network_outbound" {
+  // S3 Gateway interfaces are implemented at the routing level which means we
+  // can avoid the metered billing of a VPC endpoint interface by allowing
+  // outbound traffic to the public IP ranges, which will be routed through
+  // the Gateway interface:
+  // https://docs.aws.amazon.com/AmazonS3/latest/userguide/privatelink-interface-endpoints.html
+  description       = "Security group rule for Prefect Server running in Fargate."
+  type              = "egress"
+  security_group_id = aws_security_group.prefect_worker.id
+  from_port         = 0
+  to_port           = 0
+  protocol          = "all"
+  cidr_blocks       = ["0.0.0.0/0"]
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,19 @@
+output "prefect_worker_service_id" {
+  value = aws_ecs_service.prefect_worker_service.id
+}
+
+output "prefect_worker_execution_role_arn" {
+  value = aws_iam_role.prefect_worker_execution_role.arn
+}
+
+output "prefect_worker_task_role_arn" {
+  value = var.worker_task_role_arn == null ? aws_iam_role.prefect_worker_task_role[0].arn : var.worker_task_role_arn
+}
+
+output "prefect_worker_security_group" {
+  value = aws_security_group.prefect_worker.id
+}
+
+output "prefect_worker_cluster_name" {
+  value = aws_ecs_cluster.prefect_worker_cluster.name
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,89 @@
+variable "worker_cpu" {
+  description = "CPU units to allocate to the worker"
+  default     = 1024
+  type        = number
+}
+
+variable "worker_desired_count" {
+  description = "Number of workers to run"
+  default     = 1
+  type        = number
+}
+
+variable "worker_extra_pip_packages" {
+  description = "Packages to install on the worker assuming image is based on prefecthq/prefect"
+  default     = "prefect-aws s3fs"
+  type        = string
+}
+
+variable "worker_image" {
+  description = "Container image for the worker. This could be the name of an image in a public repo or an ECR ARN"
+  default     = "prefecthq/prefect:3-python3.11"
+  type        = string
+}
+
+variable "worker_log_retention_in_days" {
+  description = "Number of days to retain worker logs"
+  default     = 30
+  type        = number
+}
+
+variable "worker_memory" {
+  description = "Memory units to allocate to the worker"
+  default     = 2048
+  type        = number
+}
+
+variable "worker_work_pool_name" {
+  description = "Work pool that the worker should poll"
+  type        = string
+}
+
+variable "worker_subnets" {
+  description = "Subnet(s) to use for the worker"
+  type        = list(string)
+}
+
+variable "worker_task_role_arn" {
+  description = "Optional task role ARN to pass to the worker. If not defined, a task role will be created"
+  default     = null
+  type        = string
+}
+
+variable "name" {
+  description = "Unique name for this worker deployment"
+  type        = string
+}
+
+variable "prefect_account_id" {
+  description = "Prefect Cloud account ID"
+  type        = string
+}
+
+variable "prefect_workspace_id" {
+  description = "Prefect Cloud workspace ID"
+  type        = string
+}
+
+variable "prefect_api_key" {
+  description = "Prefect Cloud API key"
+  type        = string
+  sensitive   = true
+}
+
+variable "vpc_id" {
+  description = "VPC ID in which to create all resources"
+  type        = string
+}
+
+variable "secrets_manager_recovery_in_days" {
+  type        = number
+  default     = 30
+  description = "Deletion delay for AWS Secrets Manager upon resource destruction"
+}
+
+variable "worker_type" {
+  type        = string
+  default     = "ecs"
+  description = "Prefect worker type that gets passed into the Prefect worker start command"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary

Adds a modernized version of our [previous ECS worker module](https://github.com/PrefectHQ/prefect-recipes/tree/main/devops/infrastructure-as-code/aws/tf-prefect2-ecs-worker).

Related to https://linear.app/prefect/issue/PLA-1072/create-opinionated-terraform-module-that-deploys-an-aws-ecs-cluster

Related to https://github.com/PrefectHQ/examples/issues/11

Moved from https://github.com/PrefectHQ/examples/pull/17.

Tested using the `examples/ecs-worker` example:

<img width="1050" alt="image" src="https://github.com/user-attachments/assets/459d54dd-90fe-4f89-bf89-9ca5bbb92253" />



## To do
- [x] Copy over existing, archived module
- [x] Update module to current specs/standards
- [x] Test the module

## Acceptance criteria
- [x] Takes in minimal input / configuration from the user (not intended to be highly configurable/used in production, but a good starting point)
- [x] Comprehensive readme / how to use / deploy