### PR TITLE
fix(ci): 💚  create unique secret per run to avoid deletion window

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@
 data "aws_region" "current" {}
 
 resource "aws_secretsmanager_secret" "prefect_api_key" {
-  name                    = "prefect-api-key-${var.name}"
+  name_prefix             = "prefect-api-key-${var.name}-"
   recovery_window_in_days = var.secrets_manager_recovery_in_days
 }
 

--- a/network.tf
+++ b/network.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "prefect_worker" {
-  name        = "prefect-worker-sg-${var.name}"
+  name_prefix = "prefect-worker-sg-${var.name}-"
   description = "ECS Prefect worker"
   vpc_id      = var.vpc_id
 }


### PR DESCRIPTION
When this module is destroyed and recreated, the Secrets Manager secret fails to create because the name collides with a secret marked for deletion. This is because the module is not generating a new name for the resource in AWS Secrets Manager each time.

This situation is easy to resolve by refactoring to use `name_prefix` instead of `name` for the secret. Since this is basically an "internal use only" type of resource, there shouldn't be any adverse consequences to letting Terraform append its own uniqueness to the name.