### PR TITLE
refactor(ci): 🎨 more destroyable/reusable TF stack

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -54,7 +54,7 @@ resource "aws_ecs_task_definition" "prefect_worker_task_definition" {
 
   // Task role allows tasks and services to access other AWS resources.
   // Use worker_task_role_arn if provided, otherwise populate with default.
-  task_role_arn = var.worker_task_role_arn == null ? aws_iam_role.prefect_worker_task_role[0].arn : var.worker_task_role_arn
+  task_role_arn = coalesce(var.worker_task_role_arn, aws_iam_role.prefect_worker_task_role.*.arn...)
 }
 
 resource "aws_ecs_service" "prefect_worker_service" {

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@
 data "aws_region" "current" {}
 
 resource "aws_secretsmanager_secret" "prefect_api_key" {
-  name                    = "prefect-api-key-${var.name}"
+  name_prefix             = "prefect-api-key-${var.name}-"
   recovery_window_in_days = var.secrets_manager_recovery_in_days
 }
 

--- a/network.tf
+++ b/network.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "prefect_worker" {
-  name        = "prefect-worker-sg-${var.name}"
+  name_prefix = "prefect-worker-sg-${var.name}-"
   description = "ECS Prefect worker"
   vpc_id      = var.vpc_id
 }


### PR DESCRIPTION
Using this Terraform module in a TF stack which is destroyed and subsequently re-applied fails to redeploy. Ideally this module would be resilient to multiple cycles of `terraform apply` and `terraform destroy`. This is easy to achieve with the `name_prefix` functionality that AWS provides in their Terraform provider on many of their resources.

The Secrets Manager secret resource is the most in need of this. Because of the nature of deleting secrets being itself a security event, AWS prevents secrets from being completely destroyed until a minimum of 7 calendar days have passed, to partially mitigate possible denial-of-service attacks against the secret (malicious actor deletes a secret which is still needed). Since the existing Terraform resource names the name of the secret as a static string, Terraform will try to recreate the secret with the same name that was just deleted. But since that secret is protected from full deletion for a minimum of 7 days, Terraform cannot reuse the name of that secret. Since the name of the secret is effectively only consumed within the inner workings of this module, it should be of no consequence if the secret name in AWS has Terraform-managed pseudorandomness appended to it.

The security group is less impossible to reuse, but still causes an error upon reuse if it failed to delete. I would suggest using `name_prefix` here as well.