### PR TITLE
fix: 👷 specify Task family instead of specific revision

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -62,7 +62,7 @@ resource "aws_ecs_service" "prefect_worker_service" {
   cluster         = aws_ecs_cluster.prefect_worker_cluster.id
   desired_count   = var.worker_desired_count
   launch_type     = "FARGATE"
-  task_definition = aws_ecs_task_definition.prefect_worker_task_definition.arn
+  task_definition = aws_ecs_task_definition.prefect_worker_task_definition.arn_without_revision
 
   network_configuration {
     assign_public_ip = false

--- a/ecs.tf
+++ b/ecs.tf
@@ -69,4 +69,13 @@ resource "aws_ecs_service" "prefect_worker_service" {
     security_groups  = [aws_security_group.prefect_worker.id]
     subnets          = var.worker_subnets
   }
+
+  lifecycle {
+    replace_triggered_by = [
+      aws_security_group.prefect_worker,
+      aws_security_group_rule.network_outbound,
+      aws_ecs_task_definition.prefect_worker_task_definition,
+      aws_ecs_cluster.prefect_worker_cluster,
+    ]
+  }
 }


### PR DESCRIPTION
For my use case, specifying the task family instead of revision number one worked better. I'd like to suggest this become the default behavior for the module.

Full disclosure: I'm not a Prefect master, so there may be great reasons to keep this specified to the ARN and not use family here.