### PR TITLE
chore: ⬆️ allow AWS provider to be upgraded beyond v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,13 +136,13 @@ make docs
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 

--- a/ecs.tf
+++ b/ecs.tf
@@ -42,7 +42,7 @@ resource "aws_ecs_task_definition" "prefect_worker_task_definition" {
         logDriver = "awslogs"
         options = {
           awslogs-group         = aws_cloudwatch_log_group.prefect_worker_log_group.name
-          awslogs-region        = data.aws_region.current.name
+          awslogs-region        = data.aws_region.current.region
           awslogs-stream-prefix = "prefect-worker-${var.name}"
         }
       }

--- a/versions.tf
+++ b/versions.tf
@@ -2,8 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0"
     }
   }
 }
-


### PR DESCRIPTION
AWS recently started forcing AWS provider v6 as the minimum version allowable when consuming their published Terraform modules, for example:
- [terraform-aws-s3-bucket](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/pull/335)
- [terraform-aws-vpc](https://github.com/terraform-aws-modules/terraform-aws-vpc/pull/1208)
- etc.

When this module coexists in the same Terraform stack as these other modules, it results in unresolvable Terraform provider version errors:
<img width="588" alt="image" src="https://github.com/user-attachments/assets/90bf47ab-e1d4-4069-a5c8-b57a2b69a353" />

Would like to allow the AWS provider to be upgraded, unless there's a specific reason that this module must remain on v5 (Not likely at all).