### PR TITLE
feat(ci): 🔊 output ECS resources' attributes

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -13,7 +13,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install tool dependencies
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@v3
       - uses: pre-commit/action@v3.0.1

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+docs:
+	terraform-docs markdown table --output-file README.md --output-mode inject .

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,0 @@
-docs:
-	terraform-docs markdown table --output-file README.md --output-mode inject .

--- a/README.md
+++ b/README.md
@@ -194,9 +194,12 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_prefect_worker_cluster_name"></a> [prefect\_worker\_cluster\_name](#output\_prefect\_worker\_cluster\_name) | n/a |
-| <a name="output_prefect_worker_execution_role_arn"></a> [prefect\_worker\_execution\_role\_arn](#output\_prefect\_worker\_execution\_role\_arn) | n/a |
-| <a name="output_prefect_worker_security_group"></a> [prefect\_worker\_security\_group](#output\_prefect\_worker\_security\_group) | n/a |
-| <a name="output_prefect_worker_service_id"></a> [prefect\_worker\_service\_id](#output\_prefect\_worker\_service\_id) | n/a |
-| <a name="output_prefect_worker_task_role_arn"></a> [prefect\_worker\_task\_role\_arn](#output\_prefect\_worker\_task\_role\_arn) | n/a |
+| <a name="output_ecs_cluster"></a> [ecs\_cluster](#output\_ecs\_cluster) | Full aws\_ecs\_cluster object for the Prefect worker cluster (all attributes as exposed by the resource). |
+| <a name="output_ecs_service"></a> [ecs\_service](#output\_ecs\_service) | Full aws\_ecs\_service object for the Prefect worker service (all attributes as exposed by the resource). |
+| <a name="output_ecs_task_definition"></a> [ecs\_task\_definition](#output\_ecs\_task\_definition) | Full aws\_ecs\_task\_definition object for the Prefect worker (all attributes as exposed by the resource). |
+| <a name="output_prefect_worker_cluster_name"></a> [prefect\_worker\_cluster\_name](#output\_prefect\_worker\_cluster\_name) | Name of the ECS cluster hosting the Prefect worker service. |
+| <a name="output_prefect_worker_execution_role_arn"></a> [prefect\_worker\_execution\_role\_arn](#output\_prefect\_worker\_execution\_role\_arn) | ARN of the IAM execution role used by the Prefect worker task definition (pull images, write logs). |
+| <a name="output_prefect_worker_security_group"></a> [prefect\_worker\_security\_group](#output\_prefect\_worker\_security\_group) | ID of the security group attached to the Prefect worker service ENIs. |
+| <a name="output_prefect_worker_service_id"></a> [prefect\_worker\_service\_id](#output\_prefect\_worker\_service\_id) | ID of the AWS ECS service that runs the Prefect worker tasks. |
+| <a name="output_prefect_worker_task_role_arn"></a> [prefect\_worker\_task\_role\_arn](#output\_prefect\_worker\_task\_role\_arn) | ARN of the IAM task role assumed by Prefect worker tasks (may be provided via var.worker\_task\_role\_arn or created by this module). |
 <!-- END_TF_DOCS -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,31 +1,39 @@
 output "prefect_worker_service_id" {
+  description = "ID of the AWS ECS service that runs the Prefect worker tasks."
   value = aws_ecs_service.prefect_worker_service.id
 }
 
 output "prefect_worker_execution_role_arn" {
+  description = "ARN of the IAM execution role used by the Prefect worker task definition (pull images, write logs)."
   value = aws_iam_role.prefect_worker_execution_role.arn
 }
 
 output "prefect_worker_task_role_arn" {
+  description = "ARN of the IAM task role assumed by Prefect worker tasks (may be provided via var.worker_task_role_arn or created by this module)."
   value = var.worker_task_role_arn == null ? aws_iam_role.prefect_worker_task_role[0].arn : var.worker_task_role_arn
 }
 
 output "prefect_worker_security_group" {
+  description = "ID of the security group attached to the Prefect worker service ENIs."
   value = aws_security_group.prefect_worker.id
 }
 
 output "prefect_worker_cluster_name" {
+  description = "Name of the ECS cluster hosting the Prefect worker service."
   value = aws_ecs_cluster.prefect_worker_cluster.name
 }
 
 output "ecs_cluster" {
+  description = "Full aws_ecs_cluster object for the Prefect worker cluster (all attributes as exposed by the resource)."
   value = aws_ecs_cluster.prefect_worker_cluster
 }
 
 output "ecs_service" {
+  description = "Full aws_ecs_service object for the Prefect worker service (all attributes as exposed by the resource)."
   value = aws_ecs_service.prefect_worker_service
 }
 
 output "ecs_task_definition" {
+  description = "Full aws_ecs_task_definition object for the Prefect worker (all attributes as exposed by the resource)."
   value = aws_ecs_task_definition.prefect_worker_task_definition
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,39 +1,39 @@
 output "prefect_worker_service_id" {
   description = "ID of the AWS ECS service that runs the Prefect worker tasks."
-  value = aws_ecs_service.prefect_worker_service.id
+  value       = aws_ecs_service.prefect_worker_service.id
 }
 
 output "prefect_worker_execution_role_arn" {
   description = "ARN of the IAM execution role used by the Prefect worker task definition (pull images, write logs)."
-  value = aws_iam_role.prefect_worker_execution_role.arn
+  value       = aws_iam_role.prefect_worker_execution_role.arn
 }
 
 output "prefect_worker_task_role_arn" {
   description = "ARN of the IAM task role assumed by Prefect worker tasks (may be provided via var.worker_task_role_arn or created by this module)."
-  value = var.worker_task_role_arn == null ? aws_iam_role.prefect_worker_task_role[0].arn : var.worker_task_role_arn
+  value       = var.worker_task_role_arn == null ? aws_iam_role.prefect_worker_task_role[0].arn : var.worker_task_role_arn
 }
 
 output "prefect_worker_security_group" {
   description = "ID of the security group attached to the Prefect worker service ENIs."
-  value = aws_security_group.prefect_worker.id
+  value       = aws_security_group.prefect_worker.id
 }
 
 output "prefect_worker_cluster_name" {
   description = "Name of the ECS cluster hosting the Prefect worker service."
-  value = aws_ecs_cluster.prefect_worker_cluster.name
+  value       = aws_ecs_cluster.prefect_worker_cluster.name
 }
 
 output "ecs_cluster" {
   description = "Full aws_ecs_cluster object for the Prefect worker cluster (all attributes as exposed by the resource)."
-  value = aws_ecs_cluster.prefect_worker_cluster
+  value       = aws_ecs_cluster.prefect_worker_cluster
 }
 
 output "ecs_service" {
   description = "Full aws_ecs_service object for the Prefect worker service (all attributes as exposed by the resource)."
-  value = aws_ecs_service.prefect_worker_service
+  value       = aws_ecs_service.prefect_worker_service
 }
 
 output "ecs_task_definition" {
   description = "Full aws_ecs_task_definition object for the Prefect worker (all attributes as exposed by the resource)."
-  value = aws_ecs_task_definition.prefect_worker_task_definition
+  value       = aws_ecs_task_definition.prefect_worker_task_definition
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,15 @@ output "prefect_worker_security_group" {
 output "prefect_worker_cluster_name" {
   value = aws_ecs_cluster.prefect_worker_cluster.name
 }
+
+output "ecs_cluster" {
+  value = aws_ecs_cluster.prefect_worker_cluster
+}
+
+output "ecs_service" {
+  value = aws_ecs_service.prefect_worker_service
+}
+
+output "ecs_task_definition" {
+  value = aws_ecs_task_definition.prefect_worker_task_definition
+}


### PR DESCRIPTION
Surfacing the three AWS ECS resources so that they can be referenced downstream or elsewhere in the same Terraform stack which calls this module.

In my case, I'm seeking to have CI wait on the ECS service deployment to cutover successfully before marking the build as complete.

The purpose for exposing these as whole objects is so that the module caller can choose any/all attributes to access without having to resort to a data source lookup. Having a data source looking up a resource managed in the same stack results in a chicken-and-egg problem when deploying from scratch, since data sources run at plan time and must have returned a value in order to generate an apply-able plan file.