### PR TITLE
chore: touch up pre-commit and terraform-docs helpers

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -2,3 +2,11 @@
 pre-commit = '3.7.1'
 terraform = '1.10.1'
 terraform-docs = '0.19.0'
+
+[tasks.docs]
+description = "Build documentation for the module"
+run = "terraform-docs markdown table --output-file README.md ."
+
+[tasks.docs-examples]
+description = "Build documentation for the module"
+run = "terraform-docs markdown table --output-file README.md examples/ecs-worker"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,26 +1,27 @@
+---
 repos:
-- repo: https://github.com/codespell-project/codespell
-  rev: v2.2.4
-  hooks:
-    - id: codespell
-- repo: local
-  hooks:
-    - id: terraform-docs
-      name: Terraform Provider Docs
-      files: ^(infra/amazon-ecs-worker/.*)$
-      entry: terraform-docs
-      args:
-        - markdown
-        - table
-        - infra/amazon-ecs-worker
-        - --output-file
-        - README.md
-      language: system
-      pass_filenames: false
-- repo: https://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.83.5
-  hooks:
-    - id: terraform_fmt
-    - id: terraform_docs
-      args:
-        - "--args=--config=.terraform-docs.yaml"
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.4
+    hooks:
+      - id: codespell
+  - repo: local
+    hooks:
+      - id: terraform-docs-examples
+        name: Terraform Provider Docs
+        files: ^(examples/ecs-worker/.*)$
+        entry: terraform-docs
+        args:
+          - markdown
+          - table
+          - examples/ecs-worker
+          - --output-file
+          - README.md
+        language: system
+        pass_filenames: false
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.83.5
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_docs
+        args:
+          - "--args=--config=.terraform-docs.yaml"

--- a/README.md
+++ b/README.md
@@ -130,6 +130,22 @@ make docs
 - [Amazon ECS networking best practices](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/networking-best-practices.html)
 - [Troubleshoot ECS pulling secrets](https://repost.aws/knowledge-center/ecs-unable-to-pull-secrets)
 
+## Contributing
+
+Contributions are always welcome. To get started, run:
+
+```shell
+# Install pre-commit hooks
+pre-commit install
+
+# Install dependencies
+mise install
+```
+
+This uses [`mise`](https://mise.jdx.dev) as a user-friendly alternative to
+Make. You can run `mise tasks ls` to see available tasks and `mise run` to run
+a specific task. Additionally, `pre-commit` will make sure tasks like the
+generation of the documentation happens when committing changes.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements


### PR DESCRIPTION
- Updates pre-commit to point to the right 'examples/' directory
- Updates .mise.toml to include tasks for generating documentation
- Adds documentation on contributing, including how to get started

Related to https://linear.app/prefect/issue/PLA-2091/cycle-3-catch-all