### PR TITLE
feat(renovate): onboard to Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>PrefectHQ/renovate-config",
+    "github>PrefectHQ/renovate-config:terraform"
+  ]
+}


### PR DESCRIPTION
Onboards this repo to the org's central Renovate runner.

- **`renovate.json`** — extends the shared org preset + `:terraform`. Renovate's terraform manager picks up the `.tf` provider/module deps, and the `mise` manager picks up `.mise.toml`.
- No Dependabot/updatecli/mise-workflow existed to retire.
- No per-repo Renovate workflow — the central autodiscover runner handles execution once this repo is on its install list (platform#12193).

🤖 Generated with [Claude Code](https://claude.com/claude-code)