### PR TITLE
fix(renovate): per-repo postUpgradeTasks override + regenerate stale docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,13 +151,13 @@ generation of the documentation happens when committing changes.
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
@@ -167,7 +167,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_cloudwatch_log_group.prefect_worker_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_ecs_cluster.prefect_worker_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster) | resource |
 | [aws_ecs_cluster_capacity_providers.prefect_worker_cluster_capacity_providers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster_capacity_providers) | resource |
@@ -188,7 +188,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_name"></a> [name](#input\_name) | Unique name for this worker deployment | `string` | n/a | yes |
 | <a name="input_prefect_account_id"></a> [prefect\_account\_id](#input\_prefect\_account\_id) | Prefect Cloud account ID | `string` | n/a | yes |
 | <a name="input_prefect_api_key"></a> [prefect\_api\_key](#input\_prefect\_api\_key) | Prefect Cloud API key | `string` | n/a | yes |
@@ -209,7 +209,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_ecs_cluster"></a> [ecs\_cluster](#output\_ecs\_cluster) | Full aws\_ecs\_cluster object for the Prefect worker cluster (all attributes as exposed by the resource). |
 | <a name="output_ecs_service"></a> [ecs\_service](#output\_ecs\_service) | Full aws\_ecs\_service object for the Prefect worker service (all attributes as exposed by the resource). |
 | <a name="output_ecs_task_definition"></a> [ecs\_task\_definition](#output\_ecs\_task\_definition) | Full aws\_ecs\_task\_definition object for the Prefect worker (all attributes as exposed by the resource). |

--- a/examples/ecs-worker/README.md
+++ b/examples/ecs-worker/README.md
@@ -28,26 +28,26 @@ As an alternative to `prefect.yaml`, deployments can be managed by Terraform usi
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_prefect_ecs_worker"></a> [prefect\_ecs\_worker](#module\_prefect\_ecs\_worker) | prefecthq/ecs-worker/prefect | 1.0.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 5.19.0 |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_ecr_repository.example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
 
 ## Inputs

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,14 @@
   "extends": [
     "github>PrefectHQ/renovate-config",
     "github>PrefectHQ/renovate-config:terraform"
-  ]
+  ],
+  "postUpgradeTasks": {
+    "description": "Override the :terraform preset default. This repo generates docs with TWO commands (the module docs via .terraform-docs.yaml, plus a separate examples/ecs-worker README), matching its two pre-commit terraform-docs hooks. The preset default only runs the first, so the examples README would drift and fail CI.",
+    "commands": [
+      "terraform-docs --config=.terraform-docs.yaml .",
+      "terraform-docs markdown table examples/ecs-worker --output-file README.md"
+    ],
+    "fileFilters": ["**/README.md"],
+    "executionMode": "branch"
+  }
 }


### PR DESCRIPTION
Fixes pre-commit failing on Renovate (and other) PRs in this repo — e.g. #20.

## Two problems

1. **Stale docs on main.** Both `README.md` and `examples/ecs-worker/README.md` were last generated by an older terraform-docs (compact separators `|------|`). CI runs the mise-pinned **0.24.0**, which pads them (`| ---- |`). So the pre-commit `terraform-docs` hooks rewrite the files and fail on *every* PR, regardless of what it changes. Regenerated both with 0.24.0 — separator-only diff, no content change.

2. **Preset doesn't cover this repo's second doc command.** This repo has two terraform-docs pre-commit hooks: the module docs (`.terraform-docs.yaml`) and a separate `examples/ecs-worker/README.md`. The shared `:terraform` preset's `postUpgradeTasks` only runs the first, so Renovate PRs would leave the examples README stale going forward. Added a per-repo `postUpgradeTasks` override to `renovate.json` running both commands.

## Dependency

The override's examples command (`terraform-docs markdown table examples/ecs-worker ...`) requires the broadened runner allow-list in **PrefectHQ/renovate-config#16** — merge that first, or the command is rejected as disallowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)